### PR TITLE
Add Babel support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-event-mocks": "github:serverless/aws-event-mocks"
+    "aws-event-mocks": "github:serverless/aws-event-mocks",
+    "babel-register": "^6.22.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",

--- a/plugin.js
+++ b/plugin.js
@@ -24,7 +24,12 @@ class MyPlugin {
   }
 
   graphiqlStart() {
-    const fn = this.sls.config.serverless.service.functions.graphql.handler;
+    const babelOptions = ((this.sls.config.serverless.service.custom || {})['graphiql'] || {}).babelOptions;
+    if (babelOptions) {
+      require('babel-register')(babelOptions);
+    }
+    const fnName = this.options.function || 'graphql';
+    const fn = this.sls.config.serverless.service.functions[fnName].handler;
     const [handler, graphql] = fn.split('.');
     const fullPath = path.join(process.cwd(), handler);
     server.start({


### PR DESCRIPTION
Allow GraphQL function to be compiled using Babel.

Usage:

1. `npm install babel-preset-es2015 --save-dev`
2. Add this in `serverless.yml`:
```
custom:
  graphiql:
    babelOptions:
      presets: ['es2015']
```