### PR TITLE
Fix deprecation warning

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -14,10 +14,12 @@ class MyPlugin {
           function: {
             usage: 'Name of the GraphQL function. Default: graphql',
             shortcut: 'f',
+            type: 'string',
           },
           port: {
             usage: 'Port to listen on. Default: 8000',
             shortcut: 'p',
+            type: 'string',
           },
         },
       },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - MyPlugin for "function", "port"
```